### PR TITLE
Documentation Suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Setting up Django server for backend instructions:
 
 3. Activate the virtual environment. 
     ```
-    source orderlyenv/bin/activate
+    source orderlyenv/Scripts/activate
     ```
     The following command will deactivate the virtual environment if needed. 
      ```
@@ -25,7 +25,7 @@ Setting up Django server for backend instructions:
 
 4. Install required packages. 
     ```
-    pip install -r ../requirements.txt 
+    pip install -r ./requirements.txt 
     ```   
 
 5. Run tests

--- a/runOrderly.sh
+++ b/runOrderly.sh
@@ -5,4 +5,4 @@ pip install -r ./requirements.txt
 
 cd orderly
 
-py manage.py runserver
+python manage.py runserver

--- a/runOrderly.sh
+++ b/runOrderly.sh
@@ -1,0 +1,8 @@
+pip install virtualenv 
+virtualenv -p python3 orderlyenv
+source orderlyenv/Scripts/activate
+pip install -r ./requirements.txt 
+
+cd orderly
+
+py manage.py runserver


### PR DESCRIPTION
The command for creating a virtual environment didn't work, to create the environment I ran the command in my pull request.

The documentation is a little unclear about where the developer would be calling pip install from, so I am suggesting a change that makes the commands more consistent, where they all work from the Orderly/ directory

The script that I added used the changes that I described above, and worked for me as an all in one setup script for the backend. (Although I had to run the manage.py with `py` because of my machine's settings)